### PR TITLE
Add cargo profiles

### DIFF
--- a/benchmark/rust/Cargo.toml
+++ b/benchmark/rust/Cargo.toml
@@ -12,3 +12,15 @@ clap = { version = "4.5", features = ["derive"] }
 [profile.release]
 opt-level = 3
 lto = true
+
+[profile.release-tiny]
+inherits = "release"
+lto = "thin"
+strip = true
+incremental = true
+codegen-units = 1
+
+[profile.release-fast]
+inherits = "release"
+lto = false
+incremental = true


### PR DESCRIPTION
It is worth considering adding profiles to Cargo.toml – sometimes you can slightly improve the build of a test version where optimizations are not needed. Especially as the program grows and gets new features. 

```
❯ cargo build --profile=release-tiny
   Compiling libc v0.2.180
   Compiling proc-macro2 v1.0.106
   Compiling unicode-ident v1.0.22
   Compiling quote v1.0.44
   Compiling rustversion v1.0.22
   Compiling heck v0.5.0
   Compiling cfg-if v1.0.4
   Compiling parking_lot_core v0.9.12
   Compiling signal-hook v0.3.18
   Compiling smallvec v1.15.1
   Compiling rustix v0.38.44
   Compiling log v0.4.29
   Compiling scopeguard v1.2.0
   Compiling utf8parse v0.2.2
   Compiling equivalent v1.0.2
   Compiling anstyle-query v1.1.5
   Compiling anstyle v1.0.13
   Compiling either v1.15.0
   Compiling lock_api v0.4.14
   Compiling foldhash v0.1.5
   Compiling anstyle-parse v0.2.7
   Compiling is_terminal_polyfill v1.70.2
   Compiling linux-raw-sys v0.4.15
   Compiling allocator-api2 v0.2.21
   Compiling paste v1.0.15
   Compiling bitflags v2.10.0
   Compiling colorchoice v1.0.4
   Compiling strsim v0.11.1
   Compiling unicode-segmentation v1.12.0
   Compiling anstream v0.6.21
   Compiling unicode-width v0.1.14
   Compiling itoa v1.0.17
   Compiling itertools v0.13.0
   Compiling static_assertions v1.1.0
   Compiling ryu v1.0.22
   Compiling clap_lex v0.7.7
   Compiling cassowary v0.3.0
   Compiling clap_builder v4.5.56
   Compiling hashbrown v0.15.5
   Compiling castaway v0.2.4
   Compiling compact_str v0.8.1
   Compiling syn v2.0.114
   Compiling errno v0.3.14
   Compiling mio v1.1.1
   Compiling signal-hook-registry v1.4.8
   Compiling lru v0.12.5
   Compiling parking_lot v0.12.5
   Compiling signal-hook-mio v0.2.5
   Compiling crossterm v0.28.1
   Compiling unicode-truncate v1.1.0
   Compiling strum_macros v0.26.4
   Compiling instability v0.3.2
   Compiling clap_derive v4.5.55
   Compiling strum v0.26.3
   Compiling ratatui v0.28.1
   Compiling clap v4.5.56
   Compiling poc-bench v0.1.0 (/home/lucjan/Pobrane/poc-selector/benchmark/rust)
warning: direct cast of function item into an integer
   --> src/main.rs:111:50
    |
111 |         libc::signal(libc::SIGINT, handle_sigint as libc::sighandler_t);
    |                                                  ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(function_casts_as_integer)]` on by default
help: first cast to a pointer `as *const ()`
    |
111 |         libc::signal(libc::SIGINT, handle_sigint as *const () as libc::sighandler_t);
    |                                                  ++++++++++++

warning: `poc-bench` (bin "poc-bench") generated 1 warning (run `cargo fix --bin "poc-bench" -p poc-bench` to apply 1 suggestion)
    Finished `release-tiny` profile [optimized] target(s) in 12.40s
```

```
lucjan at cachyos ~/Pobrane/poc-selector/benchmark/rust 22:04:08 d9596e07 cargo-updates    
❯ cargo build --profile=release-fast
   Compiling libc v0.2.180
   Compiling proc-macro2 v1.0.106
   Compiling unicode-ident v1.0.22
   Compiling quote v1.0.44
   Compiling rustversion v1.0.22
   Compiling parking_lot_core v0.9.12
   Compiling cfg-if v1.0.4
   Compiling heck v0.5.0
   Compiling signal-hook v0.3.18
   Compiling log v0.4.29
   Compiling rustix v0.38.44
   Compiling scopeguard v1.2.0
   Compiling utf8parse v0.2.2
   Compiling smallvec v1.15.1
   Compiling linux-raw-sys v0.4.15
   Compiling allocator-api2 v0.2.21
   Compiling foldhash v0.1.5
   Compiling lock_api v0.4.14
   Compiling anstyle-parse v0.2.7
   Compiling anstyle v1.0.13
   Compiling is_terminal_polyfill v1.70.2
   Compiling equivalent v1.0.2
   Compiling paste v1.0.15
   Compiling either v1.15.0
   Compiling anstyle-query v1.1.5
   Compiling bitflags v2.10.0
   Compiling colorchoice v1.0.4
   Compiling strsim v0.11.1
   Compiling unicode-width v0.1.14
   Compiling anstream v0.6.21
   Compiling itoa v1.0.17
   Compiling static_assertions v1.1.0
   Compiling unicode-segmentation v1.12.0
   Compiling ryu v1.0.22
   Compiling clap_lex v0.7.7
   Compiling cassowary v0.3.0
   Compiling itertools v0.13.0
   Compiling hashbrown v0.15.5
   Compiling clap_builder v4.5.56
   Compiling castaway v0.2.4
   Compiling compact_str v0.8.1
   Compiling syn v2.0.114
   Compiling lru v0.12.5
   Compiling errno v0.3.14
   Compiling mio v1.1.1
   Compiling signal-hook-registry v1.4.8
   Compiling parking_lot v0.12.5
   Compiling signal-hook-mio v0.2.5
   Compiling crossterm v0.28.1
   Compiling unicode-truncate v1.1.0
   Compiling strum_macros v0.26.4
   Compiling clap_derive v4.5.55
   Compiling instability v0.3.2
   Compiling strum v0.26.3
   Compiling ratatui v0.28.1
   Compiling clap v4.5.56
   Compiling poc-bench v0.1.0 (/home/lucjan/Pobrane/poc-selector/benchmark/rust)
warning: direct cast of function item into an integer
   --> src/main.rs:111:50
    |
111 |         libc::signal(libc::SIGINT, handle_sigint as libc::sighandler_t);
    |                                                  ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(function_casts_as_integer)]` on by default
help: first cast to a pointer `as *const ()`
    |
111 |         libc::signal(libc::SIGINT, handle_sigint as *const () as libc::sighandler_t);
    |                                                  ++++++++++++

warning: `poc-bench` (bin "poc-bench") generated 1 warning (run `cargo fix --bin "poc-bench" -p poc-bench` to apply 1 suggestion)
    Finished `release-fast` profile [optimized] target(s) in 7.33s
'cargo build --profile=release-fast' time: 7,347s, cpu: 665%
```
<img width="2122" height="1322" alt="Zrzut ekranu_20260203_220559" src="https://github.com/user-attachments/assets/70bb3366-f297-4d29-8643-a402b37982e8" />

