### PR TITLE
poc-benchmark: fix cargo warning

### DIFF
--- a/benchmark/rust/src/main.rs
+++ b/benchmark/rust/src/main.rs
@@ -41,8 +41,7 @@ fn is_quit_event(ev: &Event) -> bool {
     match ev {
         Event::Key(key) if key.kind == KeyEventKind::Press => {
             key.code == KeyCode::Char('q')
-                || (key.code == KeyCode::Char('c')
-                    && key.modifiers.contains(KeyModifiers::CONTROL))
+                || (key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL))
         }
         _ => false,
     }
@@ -84,7 +83,10 @@ fn main() {
     let cli = Cli::parse();
     let sysinfo = SystemInfo::detect();
     let params = BenchParams::with_overrides(
-        sysinfo.ncpus, sysinfo.physical_cores, cli.threads, cli.background,
+        sysinfo.ncpus,
+        sysinfo.physical_cores,
+        cli.threads,
+        cli.background,
     );
 
     // Lock memory
@@ -108,7 +110,10 @@ fn main() {
 
     // Install SIGINT handler (Ctrl+C before raw mode / during calibration)
     unsafe {
-        libc::signal(libc::SIGINT, handle_sigint as *const () as libc::sighandler_t);
+        libc::signal(
+            libc::SIGINT,
+            handle_sigint as *const () as libc::sighandler_t,
+        );
     }
 
     // Pre-check sysctl: readable AND writable?
@@ -224,7 +229,9 @@ fn main() {
 
     // --- Cleanup (always runs) ---
     if dma_latency_fd >= 0 {
-        unsafe { libc::close(dma_latency_fd); }
+        unsafe {
+            libc::close(dma_latency_fd);
+        }
     }
     if sysctl_writable && orig_poc >= 0 {
         system::poc_sysctl_write(orig_poc).ok();
@@ -257,14 +264,18 @@ fn run_comparison(
     system::poc_sysctl_write(1).ok();
     let h = bench::bench_burst_async(params, discard_n, discard_w);
     let _ = run_with_progress(terminal, app, &h);
-    if quitting() { return; }
+    if quitting() {
+        return;
+    }
 
     system::poc_sysctl_write(0).ok();
     app.progress = 0.5;
     terminal.draw(|f| ui::draw(f, app)).ok();
     let h = bench::bench_burst_async(params, discard_n, discard_w);
     let _ = run_with_progress(terminal, app, &h);
-    if quitting() { return; }
+    if quitting() {
+        return;
+    }
 
     // --- Measured rounds ---
     let mut results_on = Vec::new();
@@ -281,7 +292,9 @@ fn run_comparison(
         };
 
         for &(poc_on, _label) in &order {
-            if quitting() { break 'rounds; }
+            if quitting() {
+                break 'rounds;
+            }
 
             app.phase = Phase::Running {
                 round: round + 1,
@@ -295,7 +308,9 @@ fn run_comparison(
             let h = bench::bench_burst_async(params, iterations, warmup);
             let samples = run_with_progress(terminal, app, &h);
 
-            if quitting() { break 'rounds; }
+            if quitting() {
+                break 'rounds;
+            }
 
             if !samples.is_empty() {
                 let mut s = samples.clone();

--- a/benchmark/rust/src/main.rs
+++ b/benchmark/rust/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
 
     // Install SIGINT handler (Ctrl+C before raw mode / during calibration)
     unsafe {
-        libc::signal(libc::SIGINT, handle_sigint as libc::sighandler_t);
+        libc::signal(libc::SIGINT, handle_sigint as *const () as libc::sighandler_t);
     }
 
     // Pre-check sysctl: readable AND writable?

--- a/benchmark/rust/src/stats.rs
+++ b/benchmark/rust/src/stats.rs
@@ -38,10 +38,14 @@ impl StatResult {
         let sum: f64 = samples.iter().map(|&v| v as f64).sum();
         let mean = sum / n as f64;
 
-        let var: f64 = samples.iter().map(|&v| {
-            let d = v as f64 - mean;
-            d * d
-        }).sum::<f64>() / n as f64;
+        let var: f64 = samples
+            .iter()
+            .map(|&v| {
+                let d = v as f64 - mean;
+                d * d
+            })
+            .sum::<f64>()
+            / n as f64;
 
         // Trimmed mean: drop top/bottom 1% to remove outliers
         let lo = n / 100;
@@ -53,7 +57,16 @@ impl StatResult {
             mean
         };
 
-        Self { mean, trimmed_mean, stddev: var.sqrt(), min, max, p50, p99, count: n }
+        Self {
+            mean,
+            trimmed_mean,
+            stddev: var.sqrt(),
+            min,
+            max,
+            p50,
+            p99,
+            count: n,
+        }
     }
 
     pub fn merge(results: &[StatResult]) -> Self {
@@ -69,11 +82,24 @@ impl StatResult {
         let p50 = (results.iter().map(|r| r.p50 as f64).sum::<f64>() / n) as u64;
         let p99 = (results.iter().map(|r| r.p99 as f64).sum::<f64>() / n) as u64;
         let count = results.iter().map(|r| r.count).sum();
-        Self { mean, trimmed_mean, stddev, min, max, p50, p99, count }
+        Self {
+            mean,
+            trimmed_mean,
+            stddev,
+            min,
+            max,
+            p50,
+            p99,
+            count,
+        }
     }
 
     pub fn ops_per_sec(&self) -> f64 {
-        if self.mean <= 0.0 { 0.0 } else { 1e9 / self.mean }
+        if self.mean <= 0.0 {
+            0.0
+        } else {
+            1e9 / self.mean
+        }
     }
 }
 
@@ -100,6 +126,10 @@ impl Histogram {
     }
 
     pub fn fraction(&self, bucket: usize) -> f64 {
-        if self.total == 0 { 0.0 } else { self.buckets[bucket] as f64 / self.total as f64 }
+        if self.total == 0 {
+            0.0
+        } else {
+            self.buckets[bucket] as f64 / self.total as f64
+        }
     }
 }

--- a/benchmark/rust/src/system.rs
+++ b/benchmark/rust/src/system.rs
@@ -33,7 +33,12 @@ impl SystemInfo {
         let physical_cores = detect_physical_cores(ncpus);
         let cpu_model = read_cpu_model().unwrap_or_else(|| "Unknown".into());
         let hw_features = detect_hw_features();
-        Self { ncpus, physical_cores, cpu_model, hw_features }
+        Self {
+            ncpus,
+            physical_cores,
+            cpu_model,
+            hw_features,
+        }
     }
 }
 
@@ -65,7 +70,12 @@ impl BenchParams {
             None => (available / group).max(1),
         };
         let n_idle = available.saturating_sub(n_workers * group);
-        Self { n_workers, n_background, n_idle, shadows_per_worker }
+        Self {
+            n_workers,
+            n_background,
+            n_idle,
+            shadows_per_worker,
+        }
     }
 }
 
@@ -96,16 +106,18 @@ fn detect_physical_cores(ncpus: usize) -> usize {
         let pkg = fs::read_to_string(format!(
             "/sys/devices/system/cpu/cpu{cpu}/topology/physical_package_id"
         ));
-        let core = fs::read_to_string(format!(
-            "/sys/devices/system/cpu/cpu{cpu}/topology/core_id"
-        ));
+        let core = fs::read_to_string(format!("/sys/devices/system/cpu/cpu{cpu}/topology/core_id"));
         if let (Ok(p), Ok(c)) = (pkg, core) {
             if let (Ok(p), Ok(c)) = (p.trim().parse::<i32>(), c.trim().parse::<i32>()) {
                 cores.insert((p, c));
             }
         }
     }
-    if cores.is_empty() { ncpus } else { cores.len() }
+    if cores.is_empty() {
+        ncpus
+    } else {
+        cores.len()
+    }
 }
 
 fn read_cpu_model() -> Option<String> {

--- a/benchmark/rust/src/ui.rs
+++ b/benchmark/rust/src/ui.rs
@@ -74,8 +74,8 @@ pub fn draw(f: &mut Frame, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(4),  // header
-            Constraint::Length(3),  // progress
+            Constraint::Length(4), // header
+            Constraint::Length(3), // progress
             Constraint::Min(12),   // histogram
             Constraint::Length(8), // summary
             Constraint::Length(1), // footer
@@ -95,7 +95,9 @@ fn draw_header(f: &mut Frame, area: Rect, app: &App) {
         Line::from(vec![
             Span::styled(
                 &app.system.cpu_model,
-                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 format!(" \u{2502} {} CPUs", app.system.ncpus),
@@ -137,7 +139,11 @@ fn draw_header(f: &mut Frame, area: Rect, app: &App) {
 
     let block = Block::default()
         .title(" POC Selector Benchmark ")
-        .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+        .title_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
         .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT);
     let paragraph = Paragraph::new(lines).block(block);
     f.render_widget(paragraph, area);
@@ -147,7 +153,11 @@ fn draw_progress(f: &mut Frame, area: Rect, app: &App) {
     let label = match &app.phase {
         Phase::Calibrating => "Calibrating...".to_string(),
         Phase::Discard => "Warmup (discard)...".to_string(),
-        Phase::Running { round, total_rounds, poc_on } => {
+        Phase::Running {
+            round,
+            total_rounds,
+            poc_on,
+        } => {
             let mode = if *poc_on { "POC ON" } else { "CFS" };
             format!("Round {}/{} [{}]", round, total_rounds, mode)
         }
@@ -211,8 +221,16 @@ fn draw_histogram(f: &mut Frame, area: Rect, app: &App) {
             break;
         }
         let bar_w = half_w.saturating_sub(1);
-        let on_frac = app.hist_on.as_ref().map(|h| h.fraction(bucket)).unwrap_or(0.0);
-        let off_frac = app.hist_off.as_ref().map(|h| h.fraction(bucket)).unwrap_or(0.0);
+        let on_frac = app
+            .hist_on
+            .as_ref()
+            .map(|h| h.fraction(bucket))
+            .unwrap_or(0.0);
+        let off_frac = app
+            .hist_off
+            .as_ref()
+            .map(|h| h.fraction(bucket))
+            .unwrap_or(0.0);
 
         let on_bar = render_bar(on_frac, max_frac, bar_w, COL_POC);
         let off_bar = render_bar(off_frac, max_frac, bar_w, COL_CFS);
@@ -260,14 +278,30 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &App) {
 
     let mut lines = vec![Line::from(vec![
         Span::styled(format!("{:>12}", ""), Style::default()),
-        Span::styled(format!("{:>14}", "POC ON"), Style::default().fg(COL_POC).add_modifier(Modifier::BOLD)),
-        Span::styled(format!("{:>14}", "CFS"), Style::default().fg(COL_CFS).add_modifier(Modifier::BOLD)),
-        Span::styled(format!("{:>12}", "\u{0394}"), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format!("{:>14}", "POC ON"),
+            Style::default().fg(COL_POC).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{:>14}", "CFS"),
+            Style::default().fg(COL_CFS).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{:>12}", "\u{0394}"),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
     ])];
 
     let rows: Vec<(&str, f64, f64, bool)> = vec![
         ("mean", on.mean / 1000.0, off.mean / 1000.0, true),
-        ("trimmed", on.trimmed_mean / 1000.0, off.trimmed_mean / 1000.0, true),
+        (
+            "trimmed",
+            on.trimmed_mean / 1000.0,
+            off.trimmed_mean / 1000.0,
+            true,
+        ),
         ("p50", on.p50 as f64 / 1000.0, off.p50 as f64 / 1000.0, true),
         ("p99", on.p99 as f64 / 1000.0, off.p99 as f64 / 1000.0, true),
         ("ops/sec", on.ops_per_sec(), off.ops_per_sec(), false),
@@ -280,14 +314,21 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &App) {
             0.0
         };
 
-        let is_better = if lower_is_better { delta < 0.0 } else { delta > 0.0 };
+        let is_better = if lower_is_better {
+            delta < 0.0
+        } else {
+            delta > 0.0
+        };
         let delta_color = if is_better { COL_BETTER } else { COL_WORSE };
         let arrow = if delta < 0.0 { "\u{25bc}" } else { "\u{25b2}" };
 
         let (on_str, off_str) = if label == "ops/sec" {
             (format_int(v_on), format_int(v_off))
         } else {
-            (format!("{:.2} \u{03bc}s", v_on), format!("{:.2} \u{03bc}s", v_off))
+            (
+                format!("{:.2} \u{03bc}s", v_on),
+                format!("{:.2} \u{03bc}s", v_off),
+            )
         };
 
         lines.push(Line::from(vec![
@@ -296,7 +337,9 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &App) {
             Span::styled(format!("{:>14}", off_str), Style::default().fg(COL_CFS)),
             Span::styled(
                 format!("{:>+8.1}% {}", delta, arrow),
-                Style::default().fg(delta_color).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(delta_color)
+                    .add_modifier(Modifier::BOLD),
             ),
         ]));
     }
@@ -311,11 +354,8 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
     } else {
         "Press q to abort"
     };
-    let p = Paragraph::new(Line::from(Span::styled(
-        text,
-        Style::default().fg(COL_DIM),
-    )))
-    .alignment(ratatui::layout::Alignment::Center);
+    let p = Paragraph::new(Line::from(Span::styled(text, Style::default().fg(COL_DIM))))
+        .alignment(ratatui::layout::Alignment::Center);
     f.render_widget(p, area);
 }
 
@@ -346,29 +386,14 @@ fn render_bar(frac: f64, max_frac: f64, width: usize, color: Color) -> Vec<Span<
         let before = filled - pct.len() - 1;
         let after = empty;
         vec![
-            Span::styled(
-                "\u{2588}".repeat(before + 1),
-                Style::default().fg(color),
-            ),
-            Span::styled(
-                pct,
-                Style::default().fg(Color::Black).bg(color),
-            ),
-            Span::styled(
-                " ".repeat(after),
-                Style::default().fg(COL_DIM),
-            ),
+            Span::styled("\u{2588}".repeat(before + 1), Style::default().fg(color)),
+            Span::styled(pct, Style::default().fg(Color::Black).bg(color)),
+            Span::styled(" ".repeat(after), Style::default().fg(COL_DIM)),
         ]
     } else {
         vec![
-            Span::styled(
-                "\u{2588}".repeat(filled),
-                Style::default().fg(color),
-            ),
-            Span::styled(
-                " ".repeat(empty),
-                Style::default().fg(COL_DIM),
-            ),
+            Span::styled("\u{2588}".repeat(filled), Style::default().fg(color)),
+            Span::styled(" ".repeat(empty), Style::default().fg(COL_DIM)),
         ]
     }
 }
@@ -391,13 +416,23 @@ fn center_pad(s: &str, width: usize) -> String {
         return s[..width].to_string();
     }
     let pad = (width - s.len()) / 2;
-    format!("{}{}{}", " ".repeat(pad), s, " ".repeat(width - pad - s.len()))
+    format!(
+        "{}{}{}",
+        " ".repeat(pad),
+        s,
+        " ".repeat(width - pad - s.len())
+    )
 }
 
 fn format_int(v: f64) -> String {
     let v = v as u64;
     if v >= 1_000_000 {
-        format!("{},{:03},{:03}", v / 1_000_000, (v / 1_000) % 1_000, v % 1_000)
+        format!(
+            "{},{:03},{:03}",
+            v / 1_000_000,
+            (v / 1_000) % 1_000,
+            v % 1_000
+        )
     } else if v >= 1_000 {
         format!("{},{:03}", v / 1_000, v % 1_000)
     } else {
@@ -414,7 +449,10 @@ pub fn print_summary(app: &App) {
     println!("=== POC Selector Benchmark Results ===");
     println!("CPU: {}", app.system.cpu_model);
     let hw = &app.system.hw_features;
-    println!("HW:  POPCNT={} CTZ={} PTSelect={}", hw.popcnt, hw.ctz, hw.ptselect);
+    println!(
+        "HW:  POPCNT={} CTZ={} PTSelect={}",
+        hw.popcnt, hw.ctz, hw.ptselect
+    );
     println!(
         "Config: {} CPUs, {} workers, {} bg, {} idle, {} shadows/w",
         app.system.ncpus,
@@ -432,13 +470,15 @@ pub fn print_summary(app: &App) {
 
     if let (Some(on), Some(off)) = (app.final_on.as_ref(), app.final_off.as_ref()) {
         println!();
-        println!(
-            "{:>12} {:>14} {:>14} {:>12}",
-            "", "POC ON", "CFS", "Δ"
-        );
+        println!("{:>12} {:>14} {:>14} {:>12}", "", "POC ON", "CFS", "Δ");
         let rows: Vec<(&str, f64, f64, bool)> = vec![
             ("mean", on.mean / 1000.0, off.mean / 1000.0, true),
-            ("trimmed", on.trimmed_mean / 1000.0, off.trimmed_mean / 1000.0, true),
+            (
+                "trimmed",
+                on.trimmed_mean / 1000.0,
+                off.trimmed_mean / 1000.0,
+                true,
+            ),
             ("p50", on.p50 as f64 / 1000.0, off.p50 as f64 / 1000.0, true),
             ("p99", on.p99 as f64 / 1000.0, off.p99 as f64 / 1000.0, true),
             ("min", on.min as f64 / 1000.0, off.min as f64 / 1000.0, true),


### PR DESCRIPTION
**Before**

```
❯ cargo build --release
   Compiling libc v0.2.180
   Compiling proc-macro2 v1.0.106
   Compiling unicode-ident v1.0.22
   Compiling quote v1.0.44
   Compiling rustversion v1.0.22
   Compiling heck v0.5.0
   Compiling cfg-if v1.0.4
   Compiling parking_lot_core v0.9.12
   Compiling signal-hook v0.3.18
   Compiling scopeguard v1.2.0
   Compiling utf8parse v0.2.2
   Compiling rustix v0.38.44
   Compiling smallvec v1.15.1
   Compiling log v0.4.29
   Compiling bitflags v2.10.0
   Compiling is_terminal_polyfill v1.70.2
   Compiling paste v1.0.15
   Compiling lock_api v0.4.14
   Compiling anstyle-parse v0.2.7
   Compiling anstyle v1.0.13
   Compiling equivalent v1.0.2
   Compiling anstyle-query v1.1.5
   Compiling linux-raw-sys v0.4.15
   Compiling allocator-api2 v0.2.21
   Compiling either v1.15.0
   Compiling colorchoice v1.0.4
   Compiling foldhash v0.1.5
   Compiling strsim v0.11.1
   Compiling unicode-width v0.1.14
   Compiling ryu v1.0.22
   Compiling itoa v1.0.17
   Compiling anstream v0.6.21
   Compiling unicode-segmentation v1.12.0
   Compiling clap_lex v0.7.7
   Compiling static_assertions v1.1.0
   Compiling cassowary v0.3.0
   Compiling itertools v0.13.0
   Compiling clap_builder v4.5.56
   Compiling castaway v0.2.4
   Compiling hashbrown v0.15.5
   Compiling compact_str v0.8.1
   Compiling syn v2.0.114
   Compiling errno v0.3.14
   Compiling mio v1.1.1
   Compiling lru v0.12.5
   Compiling signal-hook-registry v1.4.8
   Compiling parking_lot v0.12.5
   Compiling signal-hook-mio v0.2.5
   Compiling crossterm v0.28.1
   Compiling unicode-truncate v1.1.0
   Compiling strum_macros v0.26.4
   Compiling clap_derive v4.5.55
   Compiling instability v0.3.2
   Compiling strum v0.26.3
   Compiling ratatui v0.28.1
   Compiling clap v4.5.56
   Compiling poc-bench v0.1.0 (/home/lucjan/Pobrane/test/poc-selector/benchmark/rust)
warning: direct cast of function item into an integer
   --> src/main.rs:111:50
    |
111 |         libc::signal(libc::SIGINT, handle_sigint as libc::sighandler_t);
    |                                                  ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(function_casts_as_integer)]` on by default
help: first cast to a pointer `as *const ()`
    |
111 |         libc::signal(libc::SIGINT, handle_sigint as *const () as libc::sighandler_t);
    |                                                  ++++++++++++

warning: `poc-bench` (bin "poc-bench") generated 1 warning (run `cargo fix --bin "poc-bench" -p poc-bench` to apply 1 suggestion)
    Finished `release` profile [optimized] target(s) in 16.02s
'cargo build --release' time: 16,038s, cpu: 253%
```

**After**

```
lucjan at cachyos ~/Pobrane/test/poc-selector/benchmark/rust 9:22:36 5c76f5b4 cargo-fix-warning    
❯ cargo build --release
   Compiling libc v0.2.180
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.44
   Compiling unicode-ident v1.0.22
   Compiling rustversion v1.0.22
   Compiling cfg-if v1.0.4
   Compiling heck v0.5.0
   Compiling parking_lot_core v0.9.12
   Compiling signal-hook v0.3.18
   Compiling utf8parse v0.2.2
   Compiling scopeguard v1.2.0
   Compiling rustix v0.38.44
   Compiling log v0.4.29
   Compiling smallvec v1.15.1
   Compiling anstyle v1.0.13
   Compiling colorchoice v1.0.4
   Compiling either v1.15.0
   Compiling anstyle-parse v0.2.7
   Compiling lock_api v0.4.14
   Compiling allocator-api2 v0.2.21
   Compiling paste v1.0.15
   Compiling is_terminal_polyfill v1.70.2
   Compiling linux-raw-sys v0.4.15
   Compiling equivalent v1.0.2
   Compiling bitflags v2.10.0
   Compiling foldhash v0.1.5
   Compiling anstyle-query v1.1.5
   Compiling unicode-width v0.1.14
   Compiling clap_lex v0.7.7
   Compiling itertools v0.13.0
   Compiling anstream v0.6.21
   Compiling itoa v1.0.17
   Compiling static_assertions v1.1.0
   Compiling strsim v0.11.1
   Compiling ryu v1.0.22
   Compiling unicode-segmentation v1.12.0
   Compiling cassowary v0.3.0
   Compiling clap_builder v4.5.56
   Compiling hashbrown v0.15.5
   Compiling castaway v0.2.4
   Compiling compact_str v0.8.1
   Compiling syn v2.0.114
   Compiling lru v0.12.5
   Compiling errno v0.3.14
   Compiling mio v1.1.1
   Compiling signal-hook-registry v1.4.8
   Compiling parking_lot v0.12.5
   Compiling signal-hook-mio v0.2.5
   Compiling crossterm v0.28.1
   Compiling unicode-truncate v1.1.0
   Compiling strum_macros v0.26.4
   Compiling instability v0.3.2
   Compiling clap_derive v4.5.55
   Compiling strum v0.26.3
   Compiling ratatui v0.28.1
   Compiling clap v4.5.56
   Compiling poc-bench v0.1.0 (/home/lucjan/Pobrane/test/poc-selector/benchmark/rust)
    Finished `release` profile [optimized] target(s) in 15.22s
'cargo build --release' time: 15,238s, cpu: 264%
```